### PR TITLE
CLI upload: use file name as image title by default

### DIFF
--- a/EasyImgur/Form1.cs
+++ b/EasyImgur/Form1.cs
@@ -395,7 +395,7 @@ namespace EasyImgur
                             // requires that the stream it was loaded from still be open, or else you get
                             // an immensely generic error. 
                             img = System.Drawing.Image.FromStream(stream);
-                            resp = ImgurAPI.UploadImage(img, GetTitleString(), GetDescriptionString(), _Anonymous);
+                            resp = ImgurAPI.UploadImage(img, string.IsNullOrEmpty(textBoxTitleFormat.Text) ? Path.GetFileName(fileName) : GetTitleString(), GetDescriptionString(), _Anonymous);
                         }
                         if (resp.success)
                         {


### PR DESCRIPTION
CLI upload: use file name as image title when no title format is set, that is by default.

P.S. it'd be nice if you add this feature to CLI album upload. [The upload code](https://github.com/bkeiren/EasyImgur/blob/5d534714ae762b3e659ffe50320b26f6b2090012/EasyImgur/ImgurAPI.cs#L306) seems strange - why the same _Title is set for every image in album?