### PR TITLE
Fix exceptions caused by invalid image files

### DIFF
--- a/EasyImgur/Form1.cs
+++ b/EasyImgur/Form1.cs
@@ -331,6 +331,10 @@ namespace EasyImgur
                     titles.Add(GetTitleString(format_context));
                     descriptions.Add(GetDescriptionString(format_context));
                 }
+                catch (ArgumentException)
+                {
+                    ShowBalloonTip(2000, "Failed", "File (" + path + ") is not a valid image file.", ToolTipIcon.Error, true);
+                }
                 catch(FileNotFoundException)
                 {
                     ShowBalloonTip(2000, "Failed", "Could not find image file on disk (" + path + "):", ToolTipIcon.Error, true);
@@ -340,7 +344,12 @@ namespace EasyImgur
                     ShowBalloonTip(2000, "Failed", "Image is in use by another program (" + path + "):", ToolTipIcon.Error, true);
                 }
             }
-
+            if (images.Count == 0)
+            {
+                Log.Error("Album upload failed: No valid images in selected images!");
+                ShowBalloonTip(2000, "Failed", "Album upload cancelled: No valid images to upload!", ToolTipIcon.Error, true);
+                return;
+            }
             APIResponses.AlbumResponse response = ImgurAPI.UploadAlbum(images.ToArray(), _AlbumTitle, _Anonymous, titles.ToArray(), descriptions.ToArray());
             if(response.success)
             {
@@ -444,6 +453,10 @@ namespace EasyImgur
                             failure++;
                             ShowBalloonTip(2000, "Failed" + fileCounterString, "Could not upload image (" + resp.status + "): " + resp.data.error, ToolTipIcon.None, true);
                         }
+                    }
+                    catch (ArgumentException)
+                    {
+                        ShowBalloonTip(2000, "Failed" + fileCounterString, "File (" + fileName + ") is not a valid image file.", ToolTipIcon.Error, true);
                     }
                     catch (System.IO.FileNotFoundException)
                     {

--- a/EasyImgur/Program.cs
+++ b/EasyImgur/Program.cs
@@ -48,6 +48,10 @@ namespace EasyImgur
                     Application.SetCompatibleTextRenderingDefault(false);
                     Form1 form = new Form1(singleInstance, args);
                     Properties.Settings.Default.Reload();   // To make sure we can access the current settings.
+
+#if DEBUG           // We want VS to get the source of the exception instead of coming to this throw when debugging
+                    Application.Run(); 
+#else
                     try
                     {
                         Application.Run();
@@ -57,6 +61,7 @@ namespace EasyImgur
                         Log.Error("Fatal exception in main thread: " + ex.ToString());
                         throw; // crash and burn; I'm not sure it's safe to show a message box so just crash
                     }
+#endif
                 }
                 else
                     singleInstance.PassArgumentsToFirstInstance(args);


### PR DESCRIPTION
 - When individual file chosen for uploading is not a valid image file
 - When album upload fails when no valid images are chosen
 - Add balloon tips for both incidents

This is a fix for issue #18 