### PR TITLE
Fix unnecessary ArgumentNullExceptions in FindDLL and UpdateRegistry

### DIFF
--- a/EasyImgur/Form1.cs
+++ b/EasyImgur/Form1.cs
@@ -527,7 +527,7 @@ namespace EasyImgur
 
             using(Microsoft.Win32.RegistryKey registryKey = Microsoft.Win32.Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true))
             {
-                if(checkBoxLaunchAtBoot.Checked)
+                if (checkBoxLaunchAtBoot.Checked)
                 {
                     // If the checkbox was marked, set a value which will make EasyImgur start at boot.
                     registryKey.SetValue("EasyImgur", QuotedApplicationPath);
@@ -582,8 +582,8 @@ namespace EasyImgur
                         }
                         else
                         {
-                            try { shell.DeleteSubKeyTree("imguruploadanonymous"); } catch { }
-                            try { shell.DeleteSubKeyTree("imgurupload"); } catch { }
+                            shell.DeleteSubKeyTree("imguruploadanonymous", false);
+                            shell.DeleteSubKeyTree("imgurupload", false);
                         }
                     }
         }

--- a/EasyImgur/Program.cs
+++ b/EasyImgur/Program.cs
@@ -74,13 +74,21 @@ namespace EasyImgur
             String assembly_name = "EasyImgur." + keyName + ".dll";
             using (Stream stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream(assembly_name))
             {
-                byte[] buffer = new BinaryReader(stream).ReadBytes((int)stream.Length);
-                System.Reflection.Assembly assembly = System.Reflection.Assembly.Load(buffer);
-                m_Libs[keyName] = assembly;
+                if (stream == null)
+                {
+                    Log.Warning("Couldn't resolve assembly: '" + assembly_name + "'");
+                    return null;
+                }
+                using (var reader = new BinaryReader(stream))
+                {
+                    byte[] buffer = reader.ReadBytes((int)stream.Length);
+                    System.Reflection.Assembly assembly = System.Reflection.Assembly.Load(buffer);
+                    m_Libs[keyName] = assembly;
 
-                Log.Info("Loaded assembly: '" + assembly_name + "'.");
+                    Log.Info("Loaded assembly: '" + assembly_name + "'.");
 
-                return assembly;
+                    return assembly;
+                }
             }
         }
 


### PR DESCRIPTION
* FindDLL method doesn't throw an exception anymore when it doesn't find an assembly and a [null `Stream` is passed to the `BinaryReader` ctor](https://github.com/bkeiren/EasyImgur/blob/31d4f7f04e573b0e979dbe8416fc1baaddb75f54/EasyImgur/Program.cs#L77).
* UpdateRegistry now uses the [DeleteSubKeyTree overload](https://msdn.microsoft.com/en-us/library/dd411622(v=vs.100).aspx) which doesn't throw an exception (when the key is not found) instead of [using `try...catch`](https://github.com/bkeiren/EasyImgur/blob/31d4f7f04e573b0e979dbe8416fc1baaddb75f54/EasyImgur/Form1.cs#L585).
* Put the `BinaryReader` inside a `using` statement because it needs to be disposed