### PR TITLE
Setting for copying HTTPS links

### DIFF
--- a/EasyImgur/Form1.Designer.cs
+++ b/EasyImgur/Form1.Designer.cs
@@ -34,6 +34,7 @@
             this.buttonApplyGeneral = new System.Windows.Forms.Button();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.checkBoxCopyHttpsLinks = new System.Windows.Forms.CheckBox();
             this.labelPortableModeNote = new System.Windows.Forms.Label();
             this.label17 = new System.Windows.Forms.Label();
             this.checkBoxGalleryUpload = new System.Windows.Forms.CheckBox();
@@ -145,6 +146,7 @@
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.checkBoxCopyHttpsLinks);
             this.tabPage1.Controls.Add(this.labelPortableModeNote);
             this.tabPage1.Controls.Add(this.label17);
             this.tabPage1.Controls.Add(this.checkBoxGalleryUpload);
@@ -172,6 +174,20 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxCopyHttpsLinks
+            // 
+            this.checkBoxCopyHttpsLinks.AutoSize = true;
+            this.checkBoxCopyHttpsLinks.Checked = global::EasyImgur.Properties.Settings.Default.copyHttpsLinks;
+            this.checkBoxCopyHttpsLinks.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::EasyImgur.Properties.Settings.Default, "copyHttpsLinks", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.checkBoxCopyHttpsLinks.Location = new System.Drawing.Point(404, 16);
+            this.checkBoxCopyHttpsLinks.Margin = new System.Windows.Forms.Padding(2);
+            this.checkBoxCopyHttpsLinks.Name = "checkBoxCopyHttpsLinks";
+            this.checkBoxCopyHttpsLinks.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.checkBoxCopyHttpsLinks.Size = new System.Drawing.Size(113, 17);
+            this.checkBoxCopyHttpsLinks.TabIndex = 22;
+            this.checkBoxCopyHttpsLinks.Text = "Copy HTTPS links";
+            this.checkBoxCopyHttpsLinks.UseVisualStyleBackColor = true;
             // 
             // labelPortableModeNote
             // 
@@ -1008,6 +1024,7 @@
         private System.Windows.Forms.ListBox contributorsList;
         private System.Windows.Forms.Label labelPortableModeNote;
         private System.Windows.Forms.Label label19;
+        private System.Windows.Forms.CheckBox checkBoxCopyHttpsLinks;
     }
 }
 

--- a/EasyImgur/Form1.cs
+++ b/EasyImgur/Form1.cs
@@ -280,7 +280,9 @@ namespace EasyImgur
                 // this doesn't need an invocation guard because this function can't be called from the context menu
                 if (Properties.Settings.Default.copyLinks)
                 {
-                    Clipboard.SetText(resp.data.link);
+                    Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
+                        ? resp.data.link.Replace("http://", "https://")
+                        : resp.data.link);
                 }
 
                 ShowBalloonTip(2000, "Success!", Properties.Settings.Default.copyLinks ? "Link copied to clipboard" : "Upload placed in history: " + resp.data.link, ToolTipIcon.None);
@@ -351,13 +353,22 @@ namespace EasyImgur
                 return;
             }
             APIResponses.AlbumResponse response = ImgurAPI.UploadAlbum(images.ToArray(), _AlbumTitle, _Anonymous, titles.ToArray(), descriptions.ToArray());
-            if(response.success)
+            if (response.success)
             {
                 // clipboard calls can only be made on an STA thread, threading model is MTA when invoked from context menu
-                if(System.Threading.Thread.CurrentThread.GetApartmentState() != System.Threading.ApartmentState.STA)
-                    this.Invoke(new Action(delegate { Clipboard.SetText(response.data.link); }));
+                if (System.Threading.Thread.CurrentThread.GetApartmentState() != System.Threading.ApartmentState.STA)
+                {
+                    this.Invoke(new Action(() =>
+                        Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
+                            ? response.data.link.Replace("http://", "https://")
+                            : response.data.link)));
+                }
                 else
-                    Clipboard.SetText(response.data.link);
+                {
+                    Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
+                        ? response.data.link.Replace("http://", "https://")
+                        : response.data.link);
+                }
 
                 ShowBalloonTip(2000, "Success!", Properties.Settings.Default.copyLinks ? "Link copied to clipboard" : "Upload placed in history: " + response.data.link, ToolTipIcon.None);
 
@@ -371,7 +382,7 @@ namespace EasyImgur
                 item.anonymous = _Anonymous;
                 item.album = true;
                 item.thumbnail = response.CoverImage.GetThumbnailImage(pictureBox1.Width, pictureBox1.Height, null, System.IntPtr.Zero);
-                Invoke(new Action(() => { History.StoreHistoryItem(item); }));
+                Invoke(new Action(() => History.StoreHistoryItem(item)));
             }
             else
                 ShowBalloonTip(2000, "Failed", "Could not upload album (" + response.status + "): " + response.data.error, ToolTipIcon.None, true);
@@ -429,10 +440,20 @@ namespace EasyImgur
                             if (Properties.Settings.Default.copyLinks)
                             {
                                 // clipboard calls can only be made on an STA thread, threading model is MTA when invoked from context menu
-                                if(System.Threading.Thread.CurrentThread.GetApartmentState() != System.Threading.ApartmentState.STA)
-                                    this.Invoke(new Action(delegate { Clipboard.SetText(resp.data.link); }));
+                                if (System.Threading.Thread.CurrentThread.GetApartmentState() !=
+                                    System.Threading.ApartmentState.STA)
+                                {
+                                    this.Invoke(new Action(() =>
+                                        Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
+                                            ? resp.data.link.Replace("http://", "https://")
+                                            : resp.data.link)));
+                                }
                                 else
-                                    Clipboard.SetText(resp.data.link);
+                                {
+                                    Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
+                                        ? resp.data.link.Replace("http://", "https://")
+                                        : resp.data.link);
+                                }
                             }
 
                             ShowBalloonTip(2000, "Success!" + fileCounterString, Properties.Settings.Default.copyLinks ? "Link copied to clipboard" : "Upload placed in history: " + resp.data.link, ToolTipIcon.None);
@@ -446,7 +467,7 @@ namespace EasyImgur
                             item.description = resp.data.description;
                             item.anonymous = _Anonymous;
                             item.thumbnail = img.GetThumbnailImage(pictureBox1.Width, pictureBox1.Height, null, System.IntPtr.Zero);
-                            Invoke(new Action(() => { History.StoreHistoryItem(item); }));
+                            Invoke(new Action(() => History.StoreHistoryItem(item)));
                         }
                         else
                         {

--- a/EasyImgur/Properties/Settings.Designer.cs
+++ b/EasyImgur/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace EasyImgur.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "12.0.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -152,6 +152,18 @@ namespace EasyImgur.Properties {
             }
             set {
                 this["uploadMultipleImagesAsGallery"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool copyHttpsLinks {
+            get {
+                return ((bool)(this["copyHttpsLinks"]));
+            }
+            set {
+                this["copyHttpsLinks"] = value;
             }
         }
     }

--- a/EasyImgur/Properties/Settings.settings
+++ b/EasyImgur/Properties/Settings.settings
@@ -35,5 +35,8 @@
     <Setting Name="uploadMultipleImagesAsGallery" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="copyHttpsLinks" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/EasyImgur/app.config
+++ b/EasyImgur/app.config
@@ -11,7 +11,7 @@
                 <value>True</value>
             </setting>
             <setting name="accountInfo" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="copyLinks" serializeAs="String">
                 <value>False</value>
@@ -20,16 +20,16 @@
                 <value>%filename%</value>
             </setting>
             <setting name="descriptionFormat" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="imageFormat" serializeAs="String">
                 <value>0</value>
             </setting>
             <setting name="accessToken" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="refreshToken" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="showNotificationOnTokenRefresh" serializeAs="String">
                 <value>False</value>
@@ -39,6 +39,9 @@
             </setting>
             <setting name="uploadMultipleImagesAsGallery" serializeAs="String">
                 <value>True</value>
+            </setting>
+            <setting name="copyHttpsLinks" serializeAs="String">
+                <value>False</value>
             </setting>
         </EasyImgur.Properties.Settings>
     </userSettings>

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Settings
 
 EasyImgur has a number of different customizable settings. These can be accessed from the *General* tab in the EasyImgur settings window:
 
-![](http://i.imgur.com/dt7bu7s.png)
+![Settings tab screenshot](http://i.imgur.com/h8WzZYU.png)
 
 - **Clear clipboard on upload**: This option determines whether the clipboard will be cleared after uploading from it.
 - **Automatically copy links to clipboard**: Determines whether links to images that have succesfully been uploaded are automatically placed on your clipboard (ready to be pasted somewhere with Ctrl+V).
+- **Copy HTTPS links**: If enabled, `http` will be replaced with `https` in links copied to the clipboard.
 - **Upload multiple images as gallery**: Determines whether multiple images upload using the file dialog window are uploaded as separate images or contained in an album.
 - **Preferred image format**: This option gives a hint to Imgur as to what image format is preferred. Note that it only hints at this by providing the source image in a certain format. Imgur can (and sometimes will) change the format to something else if it chooses to do so.
 - **Use this title format** and **Use this description format**: These define two strings that are used as the title and description for every uploaded image. The strings can contain special symbols which are converted to set values before uploading. For a complete set of symbols, click the *Format?* button. An example string containing special symbols and its final form is: *Image_%n%_%date%_%time%*, might turn out to be *Image_0_19-08-2013_13:37:00* because *%n%* is converted to an integer denoting how many images have currently been uploaded, *%date* is converted to the current date in DD-MM-YYYY format, and *%time%* is converted to the current time in HH-MM-SS format.


### PR DESCRIPTION
Created a new setting: _Copy HTTPS links_. When enabled, links will be prefixed with `https` instead of `http`.

![](http://i.imgur.com/h8WzZYU.png)

Resolves #16 