### PR TITLE
Refactoring bulk string concats, Statistics class and EasyImgur.StatisticsMetrics

### DIFF
--- a/EasyImgur/Form1.cs
+++ b/EasyImgur/Form1.cs
@@ -712,17 +712,27 @@ namespace EasyImgur
 
         private void buttonFormatHelp_Click(object sender, EventArgs e)
         {
-            FormattingHelper.FormattingScheme[] formattingSchemes = FormattingHelper.GetSchemes();
-            string helpString = "You can use strings consisting of either static characters or the following dynamic symbols, or a combination of both:\n\n";
-            foreach (FormattingHelper.FormattingScheme scheme in formattingSchemes)
+            var sb = new StringBuilder(
+                "You can use strings consisting of either static characters or " +
+                "the following dynamic symbols, or a combination of both:\n\n");
+            foreach (FormattingHelper.FormattingScheme scheme in FormattingHelper.GetSchemes())
             {
-                helpString += scheme.symbol + "  :  " + scheme.description + "\n";
+                sb.Append(scheme.symbol);
+                sb.Append("  :  ");
+                sb.Append(scheme.description);
+                sb.Append('\n');
             }
-            string exampleFormattedString = "Image_%date%_%time%";
-            helpString += "\n\nEx.: '" + exampleFormattedString + "' would become: '" + FormattingHelper.Format(exampleFormattedString, null);
+
+            const string exampleFormattedString = "Image_%date%_%time%";
+
+            sb.Append("\n\nEx.: '");
+            sb.Append(exampleFormattedString);
+            sb.Append("' would become: '");
+            sb.Append(FormattingHelper.Format(exampleFormattedString, null));
+
             Point loc = this.Location;
             loc.Offset(buttonFormatHelp.Location.X, buttonFormatHelp.Location.Y);
-            Help.ShowPopup(this, helpString, loc);
+            Help.ShowPopup(this, sb.ToString(), loc);
         }
 
         private void buttonForgetTokens_Click(object sender, EventArgs e)

--- a/EasyImgur/StatisticsMetrics/Metrics.cs
+++ b/EasyImgur/StatisticsMetrics/Metrics.cs
@@ -148,14 +148,17 @@ namespace EasyImgur.StatisticsMetrics
         {
             try
             {
-                var searcher = new ManagementObjectSearcher("SELECT * FROM " + queryTarget);
-
                 var sb = new StringBuilder();
-                foreach (ManagementObject wmiObject in searcher.Get())
+
+                using (var searcher = new ManagementObjectSearcher("SELECT * FROM " + queryTarget))
+                using (ManagementObjectCollection wmiCollection = searcher.Get())
                 {
-                    Object property = wmiObject[propertyName];
-                    if (property != null)
-                        sb.Append(property);
+                    foreach (ManagementBaseObject wmiObject in wmiCollection)
+                    {
+                        Object property = wmiObject[propertyName];
+                        if (property != null)
+                            sb.Append(property);
+                    }
                 }
 
                 return sb.ToString();
@@ -163,7 +166,7 @@ namespace EasyImgur.StatisticsMetrics
             catch (Exception ex)
             {
                 // Do nothing except log.
-                Log.Error("An exception occurred while trying to obtain some WMI object properties: " + ex.Message);
+                Log.Error("An exception occurred while trying to obtain some WMI object properties: " + ex);
             }
 
             return string.Empty;


### PR DESCRIPTION
* Changed some string concatenations incorporating loops to use StringBuilder.
* Refactored the Statistics class a little
* Refactored the EasyImgur.StatisticsMetrics namespace a little
 * Changed a (probable) accidental reference comparison in `MetricMachineID.GetNICString` to a value comparison (`!Equals(...)` instead of `... != ...`)
 * `WMI` objects in `MetricMachineID.GetPropertiesOfWMIObjects` are now properly disposed