### PR TITLE
Refactoring of APIResponses and History classes

### DIFF
--- a/EasyImgur/APIResponses/AlbumResponse.cs
+++ b/EasyImgur/APIResponses/AlbumResponse.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace EasyImgur.APIResponses
 {
@@ -10,23 +11,53 @@ namespace EasyImgur.APIResponses
     {
         public class Data : BaseResponse.BaseData
         {
-            public string id;
-            public string title;
-            public string description;
-            public int datetime;
-            public string cover;
-            public int cover_width;
-            public int cover_height;
-            public string account_url;
-            public string privacy;
-            public string layout;
-            public int views;
-            public string link;
-            public string deletehash;
-            public int images_count;
-            public ImageResponse.Data[] images;
+            [JsonProperty("id")]
+            public string Id { get; set; }
+
+            [JsonProperty("title")]
+            public string Title { get; set; }
+
+            [JsonProperty("description")]
+            public string Description { get; set; }
+
+            [JsonProperty("datetime")]
+            public int Datetime { get; set; }
+
+            [JsonProperty("cover")]
+            public string Cover { get; set; }
+
+            [JsonProperty("cover_width")]
+            public int CoverWidth { get; set; }
+
+            [JsonProperty("cover_height")]
+            public int CoverHeight { get; set; }
+
+            [JsonProperty("account_url")]
+            public string AccountUrl { get; set; }
+
+            [JsonProperty("privacy")]
+            public string Privacy { get; set; }
+
+            [JsonProperty("layout")]
+            public string Layout { get; set; }
+
+            [JsonProperty("views")]
+            public int Views { get; set; }
+
+            [JsonProperty("link")]
+            public string Link { get; set; }
+
+            [JsonProperty("deletehash")]
+            public string DeleteHash { get; set; }
+
+            [JsonProperty("images_count")]
+            public int ImageCount { get; set; }
+
+            [JsonProperty("images")]
+            public ImageResponse.Data[] Images { get; set; }
         }
-        public Data data;
-        public Image CoverImage; 
+        [JsonProperty("data")]
+        public Data ResponseData { get; set; }
+        public Image CoverImage { get; set; } 
     }
 }

--- a/EasyImgur/APIResponses/BaseResponse.cs
+++ b/EasyImgur/APIResponses/BaseResponse.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace EasyImgur.APIResponses
 {
@@ -9,12 +10,22 @@ namespace EasyImgur.APIResponses
     {
         public class BaseData
         {
-            public string error;
-            public string method;
-            public string parameters;
-            public string request;
+            [JsonProperty("error")]
+            public string Error { get; set; }
+
+            [JsonProperty("method")]
+            public string Method { get; set; }
+
+            [JsonProperty("parameters")]
+            public string Parameters { get; set; }
+
+            [JsonProperty("request")]
+            public string Request { get; set; }
         }
-        public bool success;
-        public int status;
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+
+        [JsonProperty("status")]
+        public int Status { get; set; }
     }
 }

--- a/EasyImgur/APIResponses/ImageResponse.cs
+++ b/EasyImgur/APIResponses/ImageResponse.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace EasyImgur.APIResponses
 {
@@ -9,23 +10,55 @@ namespace EasyImgur.APIResponses
     {
         public class Data : BaseResponse.BaseData
         {
-            public string id;
-            public string title;
-            public string description;
-            public string datetime;
-            public string type;
-            public bool animated;
-            public int width;
-            public int height;
-            public int size;
-            public int views;
-            public int bandwidth;
-            public bool favorite;
-            public string nsfw;
-            public string section;
-            public string deletehash;
-            public string link;
+            [JsonProperty("id")]
+            public string Id { get; set; }
+
+            [JsonProperty("title")]
+            public string Title { get; set; }
+
+            [JsonProperty("description")]
+            public string Description { get; set; }
+
+            [JsonProperty("datetime")]
+            public string Datetime { get; set; }
+
+            [JsonProperty("type")]
+            public string Type { get; set; }
+
+            [JsonProperty("animated")]
+            public bool Animated { get; set; }
+
+            [JsonProperty("width")]
+            public int Width { get; set; }
+
+            [JsonProperty("height")]
+            public int Height { get; set; }
+
+            [JsonProperty("size")]
+            public int Size { get; set; }
+
+            [JsonProperty("views")]
+            public int Views { get; set; }
+
+            [JsonProperty("bandwidth")]
+            public int Bandwidth { get; set; }
+
+            [JsonProperty("favorite")]
+            public bool Favorite { get; set; }
+
+            [JsonProperty("nsfw")]
+            public string Nsfw { get; set; }
+
+            [JsonProperty("section")]
+            public string Section { get; set; }
+
+            [JsonProperty("deletehash")]
+            public string DeleteHash { get; set; }
+
+            [JsonProperty("link")]
+            public string Link { get; set; }
         }
-        public Data data;
+        [JsonProperty("data")]
+        public Data ResponseData { get; set; }
     }
 }

--- a/EasyImgur/APIResponses/TokenResponse.cs
+++ b/EasyImgur/APIResponses/TokenResponse.cs
@@ -2,22 +2,42 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace EasyImgur.APIResponses
 {
     class TokenResponse
     {
         // Received when requesting new tokens through a pin.
-        public string bearer = string.Empty;
-        public string scope = string.Empty;
+        [JsonProperty("bearer")]
+        public string Bearer { get; set; }
+
+        [JsonProperty("scope")]
+        public string Scope { get; set; }
+
 
         // Received when refreshing tokens.
-        public string token_type = string.Empty;
-        public string account_username = string.Empty;
+        [JsonProperty("token_type")]
+        public string TokenType { get; set; }
+
+        [JsonProperty("account_username")]
+        public string AccountUsername { get; set; }
+
 
         // Always received.
-        public string access_token = string.Empty;
-        public string refresh_token = string.Empty;
-        public int expires_in = 0;
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty("refresh_token")]
+        public string RefreshToken { get; set; }
+
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+        public TokenResponse()
+        {
+            Bearer = Scope = TokenType = AccountUsername = AccessToken = RefreshToken = string.Empty;
+            ExpiresIn = 0;
+        }
     }
 }

--- a/EasyImgur/Form1.Designer.cs
+++ b/EasyImgur/Form1.Designer.cs
@@ -67,21 +67,21 @@
             this.label19 = new System.Windows.Forms.Label();
             this.checkBoxAlbum = new System.Windows.Forms.CheckBox();
             this.historyItemBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.groupBoxHistorySelection = new System.Windows.Forms.GroupBox();
+            this.buttonRemoveFromImgur = new System.Windows.Forms.Button();
+            this.buttonRemoveFromHistory = new System.Windows.Forms.Button();
             this.btnOpenImageLinkInBrowser = new System.Windows.Forms.Button();
             this.textBoxTimestamp = new System.Windows.Forms.TextBox();
             this.label9 = new System.Windows.Forms.Label();
             this.checkBoxTiedToAccount = new System.Windows.Forms.CheckBox();
             this.textBoxDeleteHash = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.pictureBoxHistoryThumb = new System.Windows.Forms.PictureBox();
             this.textBoxID = new System.Windows.Forms.TextBox();
             this.textBoxLink = new System.Windows.Forms.TextBox();
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.listBoxHistory = new System.Windows.Forms.ListBox();
-            this.groupBoxHistorySelection = new System.Windows.Forms.GroupBox();
-            this.buttonRemoveFromImgur = new System.Windows.Forms.Button();
-            this.buttonRemoveFromHistory = new System.Windows.Forms.Button();
             this.tabPage4 = new System.Windows.Forms.TabPage();
             this.versionLabel = new System.Windows.Forms.Label();
             this.label18 = new System.Windows.Forms.Label();
@@ -111,8 +111,8 @@
             this.tabPage3.SuspendLayout();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.historyItemBindingSource)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.groupBoxHistorySelection.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxHistoryThumb)).BeginInit();
             this.tabPage4.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
             this.SuspendLayout();
@@ -550,7 +550,7 @@
             this.groupBox1.Controls.Add(this.checkBoxTiedToAccount);
             this.groupBox1.Controls.Add(this.textBoxDeleteHash);
             this.groupBox1.Controls.Add(this.label3);
-            this.groupBox1.Controls.Add(this.pictureBox1);
+            this.groupBox1.Controls.Add(this.pictureBoxHistoryThumb);
             this.groupBox1.Controls.Add(this.textBoxID);
             this.groupBox1.Controls.Add(this.textBoxLink);
             this.groupBox1.Controls.Add(this.label2);
@@ -577,7 +577,7 @@
             // checkBoxAlbum
             // 
             this.checkBoxAlbum.AutoSize = true;
-            this.checkBoxAlbum.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.historyItemBindingSource, "album", true));
+            this.checkBoxAlbum.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.historyItemBindingSource, "Album", true));
             this.checkBoxAlbum.Enabled = false;
             this.checkBoxAlbum.Location = new System.Drawing.Point(235, 85);
             this.checkBoxAlbum.Margin = new System.Windows.Forms.Padding(2);
@@ -592,134 +592,6 @@
             // historyItemBindingSource
             // 
             this.historyItemBindingSource.DataSource = typeof(EasyImgur.HistoryItem);
-            // 
-            // btnOpenImageLinkInBrowser
-            // 
-            this.btnOpenImageLinkInBrowser.Location = new System.Drawing.Point(234, 10);
-            this.btnOpenImageLinkInBrowser.Name = "btnOpenImageLinkInBrowser";
-            this.btnOpenImageLinkInBrowser.Size = new System.Drawing.Size(160, 46);
-            this.btnOpenImageLinkInBrowser.TabIndex = 6;
-            this.btnOpenImageLinkInBrowser.Text = "Open in browser";
-            this.btnOpenImageLinkInBrowser.UseVisualStyleBackColor = true;
-            this.btnOpenImageLinkInBrowser.Click += new System.EventHandler(this.btnOpenImageLinkInBrowser_Click);
-            // 
-            // textBoxTimestamp
-            // 
-            this.textBoxTimestamp.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.historyItemBindingSource, "timestamp", true));
-            this.textBoxTimestamp.Location = new System.Drawing.Point(76, 83);
-            this.textBoxTimestamp.Margin = new System.Windows.Forms.Padding(2);
-            this.textBoxTimestamp.Name = "textBoxTimestamp";
-            this.textBoxTimestamp.ReadOnly = true;
-            this.textBoxTimestamp.Size = new System.Drawing.Size(149, 20);
-            this.textBoxTimestamp.TabIndex = 5;
-            // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(14, 86);
-            this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(58, 13);
-            this.label9.TabIndex = 17;
-            this.label9.Text = "Timestamp";
-            // 
-            // checkBoxTiedToAccount
-            // 
-            this.checkBoxTiedToAccount.AutoSize = true;
-            this.checkBoxTiedToAccount.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.historyItemBindingSource, "tiedToAccount", true));
-            this.checkBoxTiedToAccount.Enabled = false;
-            this.checkBoxTiedToAccount.Location = new System.Drawing.Point(235, 61);
-            this.checkBoxTiedToAccount.Margin = new System.Windows.Forms.Padding(2);
-            this.checkBoxTiedToAccount.Name = "checkBoxTiedToAccount";
-            this.checkBoxTiedToAccount.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.checkBoxTiedToAccount.Size = new System.Drawing.Size(105, 17);
-            this.checkBoxTiedToAccount.TabIndex = 15;
-            this.checkBoxTiedToAccount.TabStop = false;
-            this.checkBoxTiedToAccount.Text = "On your account";
-            this.checkBoxTiedToAccount.UseVisualStyleBackColor = true;
-            // 
-            // textBoxDeleteHash
-            // 
-            this.textBoxDeleteHash.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.historyItemBindingSource, "deletehash", true));
-            this.textBoxDeleteHash.Location = new System.Drawing.Point(76, 59);
-            this.textBoxDeleteHash.Margin = new System.Windows.Forms.Padding(2);
-            this.textBoxDeleteHash.Name = "textBoxDeleteHash";
-            this.textBoxDeleteHash.ReadOnly = true;
-            this.textBoxDeleteHash.Size = new System.Drawing.Size(149, 20);
-            this.textBoxDeleteHash.TabIndex = 4;
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(6, 62);
-            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(66, 13);
-            this.label3.TabIndex = 12;
-            this.label3.Text = "Delete Hash";
-            // 
-            // pictureBox1
-            // 
-            this.pictureBox1.DataBindings.Add(new System.Windows.Forms.Binding("Image", this.historyItemBindingSource, "thumbnail", true));
-            this.pictureBox1.Location = new System.Drawing.Point(76, 148);
-            this.pictureBox1.Margin = new System.Windows.Forms.Padding(2);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(148, 112);
-            this.pictureBox1.TabIndex = 11;
-            this.pictureBox1.TabStop = false;
-            // 
-            // textBoxID
-            // 
-            this.textBoxID.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.historyItemBindingSource, "id", true));
-            this.textBoxID.Location = new System.Drawing.Point(76, 11);
-            this.textBoxID.Margin = new System.Windows.Forms.Padding(2);
-            this.textBoxID.Name = "textBoxID";
-            this.textBoxID.ReadOnly = true;
-            this.textBoxID.Size = new System.Drawing.Size(149, 20);
-            this.textBoxID.TabIndex = 2;
-            // 
-            // textBoxLink
-            // 
-            this.textBoxLink.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.historyItemBindingSource, "link", true));
-            this.textBoxLink.Location = new System.Drawing.Point(76, 35);
-            this.textBoxLink.Margin = new System.Windows.Forms.Padding(2);
-            this.textBoxLink.Name = "textBoxLink";
-            this.textBoxLink.ReadOnly = true;
-            this.textBoxLink.Size = new System.Drawing.Size(149, 20);
-            this.textBoxLink.TabIndex = 3;
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(45, 38);
-            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(27, 13);
-            this.label2.TabIndex = 3;
-            this.label2.Text = "Link";
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(54, 14);
-            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(18, 13);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "ID";
-            // 
-            // listBoxHistory
-            // 
-            this.listBoxHistory.DataSource = this.historyItemBindingSource;
-            this.listBoxHistory.DisplayMember = "listName";
-            this.listBoxHistory.FormattingEnabled = true;
-            this.listBoxHistory.Location = new System.Drawing.Point(2, 2);
-            this.listBoxHistory.Margin = new System.Windows.Forms.Padding(2);
-            this.listBoxHistory.Name = "listBoxHistory";
-            this.listBoxHistory.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.listBoxHistory.Size = new System.Drawing.Size(171, 264);
-            this.listBoxHistory.TabIndex = 1;
-            this.listBoxHistory.SelectedIndexChanged += new System.EventHandler(this.listBoxHistory_SelectedIndexChanged);
             // 
             // groupBoxHistorySelection
             // 
@@ -756,6 +628,134 @@
             this.buttonRemoveFromHistory.UseMnemonic = false;
             this.buttonRemoveFromHistory.UseVisualStyleBackColor = true;
             this.buttonRemoveFromHistory.Click += new System.EventHandler(this.buttonRemoveFromHistory_Click);
+            // 
+            // btnOpenImageLinkInBrowser
+            // 
+            this.btnOpenImageLinkInBrowser.Location = new System.Drawing.Point(234, 10);
+            this.btnOpenImageLinkInBrowser.Name = "btnOpenImageLinkInBrowser";
+            this.btnOpenImageLinkInBrowser.Size = new System.Drawing.Size(160, 46);
+            this.btnOpenImageLinkInBrowser.TabIndex = 6;
+            this.btnOpenImageLinkInBrowser.Text = "Open in browser";
+            this.btnOpenImageLinkInBrowser.UseVisualStyleBackColor = true;
+            this.btnOpenImageLinkInBrowser.Click += new System.EventHandler(this.btnOpenImageLinkInBrowser_Click);
+            // 
+            // textBoxTimestamp
+            // 
+            this.textBoxTimestamp.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.historyItemBindingSource, "Timestamp", true));
+            this.textBoxTimestamp.Location = new System.Drawing.Point(76, 83);
+            this.textBoxTimestamp.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxTimestamp.Name = "textBoxTimestamp";
+            this.textBoxTimestamp.ReadOnly = true;
+            this.textBoxTimestamp.Size = new System.Drawing.Size(149, 20);
+            this.textBoxTimestamp.TabIndex = 5;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(14, 86);
+            this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(58, 13);
+            this.label9.TabIndex = 17;
+            this.label9.Text = "Timestamp";
+            // 
+            // checkBoxTiedToAccount
+            // 
+            this.checkBoxTiedToAccount.AutoSize = true;
+            this.checkBoxTiedToAccount.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.historyItemBindingSource, "TiedToAccount", true));
+            this.checkBoxTiedToAccount.Enabled = false;
+            this.checkBoxTiedToAccount.Location = new System.Drawing.Point(235, 61);
+            this.checkBoxTiedToAccount.Margin = new System.Windows.Forms.Padding(2);
+            this.checkBoxTiedToAccount.Name = "checkBoxTiedToAccount";
+            this.checkBoxTiedToAccount.RightToLeft = System.Windows.Forms.RightToLeft.No;
+            this.checkBoxTiedToAccount.Size = new System.Drawing.Size(105, 17);
+            this.checkBoxTiedToAccount.TabIndex = 15;
+            this.checkBoxTiedToAccount.TabStop = false;
+            this.checkBoxTiedToAccount.Text = "On your account";
+            this.checkBoxTiedToAccount.UseVisualStyleBackColor = true;
+            // 
+            // textBoxDeleteHash
+            // 
+            this.textBoxDeleteHash.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.historyItemBindingSource, "Deletehash", true));
+            this.textBoxDeleteHash.Location = new System.Drawing.Point(76, 59);
+            this.textBoxDeleteHash.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxDeleteHash.Name = "textBoxDeleteHash";
+            this.textBoxDeleteHash.ReadOnly = true;
+            this.textBoxDeleteHash.Size = new System.Drawing.Size(149, 20);
+            this.textBoxDeleteHash.TabIndex = 4;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(6, 62);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(66, 13);
+            this.label3.TabIndex = 12;
+            this.label3.Text = "Delete Hash";
+            // 
+            // pictureBoxHistoryThumb
+            // 
+            this.pictureBoxHistoryThumb.DataBindings.Add(new System.Windows.Forms.Binding("Image", this.historyItemBindingSource, "Thumbnail", true));
+            this.pictureBoxHistoryThumb.Location = new System.Drawing.Point(76, 148);
+            this.pictureBoxHistoryThumb.Margin = new System.Windows.Forms.Padding(2);
+            this.pictureBoxHistoryThumb.Name = "pictureBoxHistoryThumb";
+            this.pictureBoxHistoryThumb.Size = new System.Drawing.Size(148, 112);
+            this.pictureBoxHistoryThumb.TabIndex = 11;
+            this.pictureBoxHistoryThumb.TabStop = false;
+            // 
+            // textBoxID
+            // 
+            this.textBoxID.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.historyItemBindingSource, "Id", true));
+            this.textBoxID.Location = new System.Drawing.Point(76, 11);
+            this.textBoxID.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxID.Name = "textBoxID";
+            this.textBoxID.ReadOnly = true;
+            this.textBoxID.Size = new System.Drawing.Size(149, 20);
+            this.textBoxID.TabIndex = 2;
+            // 
+            // textBoxLink
+            // 
+            this.textBoxLink.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.historyItemBindingSource, "Link", true));
+            this.textBoxLink.Location = new System.Drawing.Point(76, 35);
+            this.textBoxLink.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxLink.Name = "textBoxLink";
+            this.textBoxLink.ReadOnly = true;
+            this.textBoxLink.Size = new System.Drawing.Size(149, 20);
+            this.textBoxLink.TabIndex = 3;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(45, 38);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(27, 13);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "Link";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(54, 14);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(18, 13);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "ID";
+            // 
+            // listBoxHistory
+            // 
+            this.listBoxHistory.DataSource = this.historyItemBindingSource;
+            this.listBoxHistory.DisplayMember = "ListName";
+            this.listBoxHistory.FormattingEnabled = true;
+            this.listBoxHistory.Location = new System.Drawing.Point(2, 2);
+            this.listBoxHistory.Margin = new System.Windows.Forms.Padding(2);
+            this.listBoxHistory.Name = "listBoxHistory";
+            this.listBoxHistory.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+            this.listBoxHistory.Size = new System.Drawing.Size(171, 264);
+            this.listBoxHistory.TabIndex = 1;
+            this.listBoxHistory.SelectedIndexChanged += new System.EventHandler(this.listBoxHistory_SelectedIndexChanged);
             // 
             // tabPage4
             // 
@@ -970,8 +970,8 @@
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.historyItemBindingSource)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.groupBoxHistorySelection.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxHistoryThumb)).EndInit();
             this.tabPage4.ResumeLayout(false);
             this.tabPage4.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
@@ -996,7 +996,7 @@
         private System.Windows.Forms.TextBox textBoxID;
         private System.Windows.Forms.TextBox textBoxLink;
         private System.Windows.Forms.CheckBox checkBoxCopyLinks;
-        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.PictureBox pictureBoxHistoryThumb;
         private System.Windows.Forms.TextBox textBoxDescriptionFormat;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.Label label5;

--- a/EasyImgur/Form1.cs
+++ b/EasyImgur/Form1.cs
@@ -279,32 +279,32 @@ namespace EasyImgur
                 ShowBalloonTip(2000, "Can't upload clipboard!", "There's no image or URL there", ToolTipIcon.Error, true);
                 return;
             }
-            if (resp.success)
+            if (resp.Success)
             {
                 // this doesn't need an invocation guard because this function can't be called from the context menu
                 if (Properties.Settings.Default.copyLinks)
                 {
                     Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
-                        ? resp.data.link.Replace("http://", "https://")
-                        : resp.data.link);
+                        ? resp.ResponseData.Link.Replace("http://", "https://")
+                        : resp.ResponseData.Link);
                 }
 
-                ShowBalloonTip(2000, "Success!", Properties.Settings.Default.copyLinks ? "Link copied to clipboard" : "Upload placed in history: " + resp.data.link, ToolTipIcon.None);
+                ShowBalloonTip(2000, "Success!", Properties.Settings.Default.copyLinks ? "Link copied to clipboard" : "Upload placed in history: " + resp.ResponseData.Link, ToolTipIcon.None);
 
                 HistoryItem item = new HistoryItem();
-                item.timestamp = DateTime.Now;
-                item.id = resp.data.id;
-                item.link = resp.data.link;
-                item.deletehash = resp.data.deletehash;
-                item.title = resp.data.title;
-                item.description = resp.data.description;
-                item.anonymous = anonymous;
+                item.Timestamp = DateTime.Now;
+                item.Id = resp.ResponseData.Id;
+                item.Link = resp.ResponseData.Link;
+                item.Deletehash = resp.ResponseData.DeleteHash;
+                item.Title = resp.ResponseData.Title;
+                item.Description = resp.ResponseData.Description;
+                item.Anonymous = anonymous;
                 if (clipboardImage != null)
-                    item.thumbnail = clipboardImage.GetThumbnailImage(pictureBox1.Width, pictureBox1.Height, null, System.IntPtr.Zero);
+                    item.Thumbnail = clipboardImage.GetThumbnailImage(pictureBoxHistoryThumb.Width, pictureBoxHistoryThumb.Height, null, System.IntPtr.Zero);
                 History.StoreHistoryItem(item);
             }
             else
-                ShowBalloonTip(2000, "Failed", "Could not upload image (" + resp.status + "):", ToolTipIcon.None, true);
+                ShowBalloonTip(2000, "Failed", "Could not upload image (" + resp.Status + "):", ToolTipIcon.None, true);
 
             if (!Properties.Settings.Default.clearClipboardOnUpload)
             {
@@ -359,39 +359,39 @@ namespace EasyImgur
                 return;
             }
             APIResponses.AlbumResponse response = ImgurAPI.UploadAlbum(images.ToArray(), _AlbumTitle, _Anonymous, titles.ToArray(), descriptions.ToArray());
-            if (response.success)
+            if (response.Success)
             {
                 // clipboard calls can only be made on an STA thread, threading model is MTA when invoked from context menu
                 if (System.Threading.Thread.CurrentThread.GetApartmentState() != System.Threading.ApartmentState.STA)
                 {
                     this.Invoke(new Action(() =>
                         Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
-                            ? response.data.link.Replace("http://", "https://")
-                            : response.data.link)));
+                            ? response.ResponseData.Link.Replace("http://", "https://")
+                            : response.ResponseData.Link)));
                 }
                 else
                 {
                     Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
-                        ? response.data.link.Replace("http://", "https://")
-                        : response.data.link);
+                        ? response.ResponseData.Link.Replace("http://", "https://")
+                        : response.ResponseData.Link);
                 }
 
-                ShowBalloonTip(2000, "Success!", Properties.Settings.Default.copyLinks ? "Link copied to clipboard" : "Upload placed in history: " + response.data.link, ToolTipIcon.None);
+                ShowBalloonTip(2000, "Success!", Properties.Settings.Default.copyLinks ? "Link copied to clipboard" : "Upload placed in history: " + response.ResponseData.Link, ToolTipIcon.None);
 
                 HistoryItem item = new HistoryItem();
-                item.timestamp = DateTime.Now;
-                item.id = response.data.id;
-                item.link = response.data.link;
-                item.deletehash = response.data.deletehash;
-                item.title = response.data.title;
-                item.description = response.data.description;
-                item.anonymous = _Anonymous;
-                item.album = true;
-                item.thumbnail = response.CoverImage.GetThumbnailImage(pictureBox1.Width, pictureBox1.Height, null, System.IntPtr.Zero);
+                item.Timestamp = DateTime.Now;
+                item.Id = response.ResponseData.Id;
+                item.Link = response.ResponseData.Link;
+                item.Deletehash = response.ResponseData.DeleteHash;
+                item.Title = response.ResponseData.Title;
+                item.Description = response.ResponseData.Description;
+                item.Anonymous = _Anonymous;
+                item.Album = true;
+                item.Thumbnail = response.CoverImage.GetThumbnailImage(pictureBoxHistoryThumb.Width, pictureBoxHistoryThumb.Height, null, System.IntPtr.Zero);
                 Invoke(new Action(() => History.StoreHistoryItem(item)));
             }
             else
-                ShowBalloonTip(2000, "Failed", "Could not upload album (" + response.status + "): " + response.data.error, ToolTipIcon.None, true);
+                ShowBalloonTip(2000, "Failed", "Could not upload album (" + response.Status + "): " + response.ResponseData.Error, ToolTipIcon.None, true);
 
             Statistics.GatherAndSend();
         }
@@ -441,7 +441,7 @@ namespace EasyImgur
                             format_context.m_Filepath = fileName;
                             resp = ImgurAPI.UploadImage(img, GetTitleString(format_context), GetDescriptionString(format_context), _Anonymous);
                         }
-                        if (resp.success)
+                        if (resp.Success)
                         {
                             success++;
 
@@ -453,34 +453,34 @@ namespace EasyImgur
                                 {
                                     this.Invoke(new Action(() =>
                                         Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
-                                            ? resp.data.link.Replace("http://", "https://")
-                                            : resp.data.link)));
+                                            ? resp.ResponseData.Link.Replace("http://", "https://")
+                                            : resp.ResponseData.Link)));
                                 }
                                 else
                                 {
                                     Clipboard.SetText(Properties.Settings.Default.copyHttpsLinks
-                                        ? resp.data.link.Replace("http://", "https://")
-                                        : resp.data.link);
+                                        ? resp.ResponseData.Link.Replace("http://", "https://")
+                                        : resp.ResponseData.Link);
                                 }
                             }
 
-                            ShowBalloonTip(2000, "Success!" + fileCounterString, Properties.Settings.Default.copyLinks ? "Link copied to clipboard" : "Upload placed in history: " + resp.data.link, ToolTipIcon.None);
+                            ShowBalloonTip(2000, "Success!" + fileCounterString, Properties.Settings.Default.copyLinks ? "Link copied to clipboard" : "Upload placed in history: " + resp.ResponseData.Link, ToolTipIcon.None);
 
                             HistoryItem item = new HistoryItem(); 
-                            item.timestamp = DateTime.Now;
-                            item.id = resp.data.id;
-                            item.link = resp.data.link;
-                            item.deletehash = resp.data.deletehash;
-                            item.title = resp.data.title;
-                            item.description = resp.data.description;
-                            item.anonymous = _Anonymous;
-                            item.thumbnail = img.GetThumbnailImage(pictureBox1.Width, pictureBox1.Height, null, System.IntPtr.Zero);
+                            item.Timestamp = DateTime.Now;
+                            item.Id = resp.ResponseData.Id;
+                            item.Link = resp.ResponseData.Link;
+                            item.Deletehash = resp.ResponseData.DeleteHash;
+                            item.Title = resp.ResponseData.Title;
+                            item.Description = resp.ResponseData.Description;
+                            item.Anonymous = _Anonymous;
+                            item.Thumbnail = img.GetThumbnailImage(pictureBoxHistoryThumb.Width, pictureBoxHistoryThumb.Height, null, System.IntPtr.Zero);
                             Invoke(new Action(() => History.StoreHistoryItem(item)));
                         }
                         else
                         {
                             failure++;
-                            ShowBalloonTip(2000, "Failed" + fileCounterString, "Could not upload image (" + resp.status + "): " + resp.data.error, ToolTipIcon.None, true);
+                            ShowBalloonTip(2000, "Failed" + fileCounterString, "Could not upload image (" + resp.Status + "): " + resp.ResponseData.Error, ToolTipIcon.None, true);
                         }
                     }
                     catch (ArgumentException)
@@ -668,7 +668,7 @@ namespace EasyImgur
             }
             else
             {
-                buttonRemoveFromImgur.Enabled = item.anonymous || (!item.anonymous && ImgurAPI.HasBeenAuthorized());
+                buttonRemoveFromImgur.Enabled = item.Anonymous || (!item.Anonymous && ImgurAPI.HasBeenAuthorized());
                 buttonRemoveFromHistory.Enabled = true;
                 btnOpenImageLinkInBrowser.Enabled = true;
             }
@@ -710,15 +710,15 @@ namespace EasyImgur
                     return;
 
                 string balloon_image_counter_text = (isMultipleImages ? (currentCount.ToString() + "/" + count.ToString()) : string.Empty);
-                string balloon_text = "Attempting to remove " + (item.album ? "album" : "image") + " " + balloon_image_counter_text + " from Imgur...";
+                string balloon_text = "Attempting to remove " + (item.Album ? "album" : "image") + " " + balloon_image_counter_text + " from Imgur...";
                 ShowBalloonTip(2000, "Hold on...", balloon_text, ToolTipIcon.None);
-                if (item.album ? ImgurAPI.DeleteAlbum(item.deletehash, item.anonymous) : ImgurAPI.DeleteImage(item.deletehash, item.anonymous))
+                if (item.Album ? ImgurAPI.DeleteAlbum(item.Deletehash, item.Anonymous) : ImgurAPI.DeleteImage(item.Deletehash, item.Anonymous))
                 {
-                    ShowBalloonTip(2000, "Success!", "Removed " + (item.album ? "album" : "image") + " " + balloon_image_counter_text + " from Imgur and history", ToolTipIcon.None);
+                    ShowBalloonTip(2000, "Success!", "Removed " + (item.Album ? "album" : "image") + " " + balloon_image_counter_text + " from Imgur and history", ToolTipIcon.None);
                     History.RemoveHistoryItem(item);
                 }
                 else
-                    ShowBalloonTip(2000, "Failed", "Failed to remove " + (item.album ? "album" : "image") + " " + balloon_image_counter_text + " from Imgur", ToolTipIcon.Error);
+                    ShowBalloonTip(2000, "Failed", "Failed to remove " + (item.Album ? "album" : "image") + " " + balloon_image_counter_text + " from Imgur", ToolTipIcon.Error);
             }
             listBoxHistory.EndUpdate();
 
@@ -833,7 +833,7 @@ namespace EasyImgur
             HistoryItem item = listBoxHistory.SelectedItem as HistoryItem;
             if (item != null)
             {
-                System.Diagnostics.Process.Start(item.link);
+                System.Diagnostics.Process.Start(item.Link);
             }
         }
 

--- a/EasyImgur/Form1.resx
+++ b/EasyImgur/Form1.resx
@@ -170,6 +170,12 @@
         2bCF1JOtRkKV44aRy8jsVT6EEAl+NCL8TFFBLvR+zXlU8H9c64sHKwWZwAAAAABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="historyItemBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>368, 17</value>
+  </metadata>
+  <metadata name="historyItemBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>368, 17</value>
+  </metadata>
   <data name="label15.Text" xml:space="preserve">
     <value>Authorizing this app enables you to add uploaded images to your 
 account, rather than uploading them anonymously.
@@ -177,12 +183,6 @@ account, rather than uploading them anonymously.
 To discard all current authorization tokens, press Forget Tokens.
 To revoke authorization of any tokens this application has, visit http://imgur.com/account/settings/apps</value>
   </data>
-  <metadata name="historyItemBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>368, 17</value>
-  </metadata>
-  <metadata name="historyItemBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>368, 17</value>
-  </metadata>
   <metadata name="trayMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>264, 17</value>
   </metadata>

--- a/EasyImgur/History.cs
+++ b/EasyImgur/History.cs
@@ -1,20 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
+using System.IO;
 using System.Linq;
-using System.Text;
+using System.Security;
 using System.Windows.Forms;
+using Newtonsoft.Json;
 
 namespace EasyImgur
 {
     static class History
     {
-        public static event HistoryItemAddedEventHandler historyItemAdded;
-        public static event HistoryItemRemovedEventHandler historyItemRemoved;
-        public delegate void HistoryItemAddedEventHandler( HistoryItem _Item );
-        public delegate void HistoryItemRemovedEventHandler( HistoryItem _Item );
+        public delegate void HistoryItemAddedEventHandler(HistoryItem item);
+        public delegate void HistoryItemRemovedEventHandler(HistoryItem item);
+        public static event HistoryItemAddedEventHandler HistoryItemAdded;
+        public static event HistoryItemRemovedEventHandler HistoryItemRemoved;
 
-        private static BindingSource m_HistoryBinding;
+        private static BindingSource _historyBinding;
 
         private static string SaveLocation 
         { 
@@ -28,141 +29,128 @@ namespace EasyImgur
             } 
         }
 
-        public static int count
+        public static int Count
         {
-            get { return m_HistoryBinding.Count; }
+            get { return _historyBinding.Count; }
         }
 
-        public static int anonymousCount
+        public static int AnonymousCount
         {
-            get 
+            get
             {
-                int c = 0;
-                foreach(HistoryItem item in m_HistoryBinding)
-                {
-                    if (item.anonymous)
-                    {
-                        ++c;
-                    }
-                }
-                return c;
+                return _historyBinding.Cast<HistoryItem>().Count(item => item.Anonymous);
             }
         }
 
         static History()
         {
             // add empty event handlers to avoid checking if the event is null
-            historyItemAdded += v => { };
-            historyItemRemoved += v => { };
+            HistoryItemAdded += v => { };
+            HistoryItemRemoved += v => { };
         }
 
-        public static int accountCount
+        public static int AccountCount
         {
-            get { return count - anonymousCount; }
+            get { return Count - AnonymousCount; }
         }
 
         // required to be the first method called
         public static void BindData(BindingSource source)
         {
-            m_HistoryBinding = source;
+            _historyBinding = source;
         }
 
         public static void InitializeFromDisk()
         {
-            List<HistoryItem> history = History.GetHistoryFromDisk();
-            if (history != null)
+            List<HistoryItem> history = GetHistoryFromDisk();
+            if (history == null) return;
+            foreach (HistoryItem item in history)
             {
-
-                foreach (HistoryItem item in history)
-                {
-                    m_HistoryBinding.Add(item);
-                    historyItemAdded(item);
-                }
+                _historyBinding.Add(item);
+                HistoryItemAdded(item);
             }
         }
 
         private static List<HistoryItem> GetHistoryFromDisk()
         {
-            string jsonString = string.Empty;
+            string jsonString;
             try
             {
-                jsonString = System.IO.File.ReadAllText(SaveLocation + "history");
+                jsonString = File.ReadAllText(SaveLocation + "history");
             }
-            catch (System.IO.FileNotFoundException ex)
+            catch (FileNotFoundException ex)
             {
                 Log.Info("Couldn't find a history file: \n" + ex.Message);
                 return null;
             }
-            catch (System.IO.IOException ex)
+            catch (IOException ex)
             {
-                Log.Error("An I/O error occurred while opening the history file: \n" + ex.Message);
+                Log.Error("An I/O error occurred while opening the history file: \n" + ex);
                 return null;
             }
-            catch (System.UnauthorizedAccessException ex)
+            catch (UnauthorizedAccessException ex)
             {
-                Log.Error("Not authorized to open the history file: \n" + ex.Message);
+                Log.Error("Not authorized to open the history file: \n" + ex);
                 return null;
             }
-            catch (System.Security.SecurityException ex)
+            catch (SecurityException ex)
             {
-                Log.Error("A security exception occurred while trying to open the history file: " + ex.Message);
-                return null;
-            }
-
-            if (jsonString == null || jsonString == string.Empty)
-            {
+                Log.Error("A security exception occurred while trying to open the history file: " + ex);
                 return null;
             }
 
-            List<HistoryItem> history = Newtonsoft.Json.JsonConvert.DeserializeObject<List<HistoryItem>>(jsonString, new ImageConverter());
-            return history;
+            if (string.IsNullOrEmpty(jsonString))
+            {
+                return null;
+            }
+
+            return JsonConvert.DeserializeObject<List<HistoryItem>>(jsonString, new ImageConverter());
         }
 
-        public static void StoreHistoryItem(HistoryItem _Item)
+        public static void StoreHistoryItem(HistoryItem item)
         {
-            if (_Item == null)
+            if (item == null)
             {
                 Log.Warning("NULL object passed to History.StoreHistoryItem. No item stored.");
                 return;
             }
-            if(m_HistoryBinding.Contains(_Item))
+            if(_historyBinding.Contains(item))
             {
                 Log.Warning("Object already in history passed to History.StoreHistoryItem. No item stored.");
                 return;
             }
 
-            m_HistoryBinding.Add(_Item);
-            historyItemAdded(_Item);
+            _historyBinding.Add(item);
+            HistoryItemAdded(item);
 
             StoreHistoryOnDisk();
         }
 
-        public static void RemoveHistoryItem(HistoryItem _Item)
+        public static void RemoveHistoryItem(HistoryItem item)
         {
             // This was changed because BindingSource doesn't support RemoveAll.
-            if(!m_HistoryBinding.Contains(_Item))
+            if(!_historyBinding.Contains(item))
             {
                 Log.Warning("Failed to remove history item from list. Item is not present in list.");
                 return;
             }
-            else
-                m_HistoryBinding.Remove(_Item);
+            _historyBinding.Remove(item);
 
             StoreHistoryOnDisk();
-            historyItemRemoved(_Item);
+            HistoryItemRemoved(item);
         }
 
         private static bool StoreHistoryOnDisk()
         {
             bool success = true;
-            string jsonString = Newtonsoft.Json.JsonConvert.SerializeObject(m_HistoryBinding.List, Newtonsoft.Json.Formatting.None, new ImageConverter());
+            string jsonString = JsonConvert.SerializeObject(_historyBinding.List, Formatting.None, new ImageConverter());
             try
             {
-                System.IO.File.WriteAllText(SaveLocation + "history", jsonString);
+                File.WriteAllText(SaveLocation + "history", jsonString);
             }
-            catch (System.Exception ex)
+            catch (Exception ex)
             {
-                Log.Error("Something went wrong while trying to store the history on disk. Exception: " + ex.ToString());
+                Log.Error("Something went wrong while trying to store the history on disk. Exception: " + ex);
                 success = false;
             }
             return success;

--- a/EasyImgur/HistoryItem.cs
+++ b/EasyImgur/HistoryItem.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Drawing;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,28 +9,52 @@ namespace EasyImgur
 {
     class HistoryItem
     {
-        // some fields are properties because only properties (not fields!) can be data bound
-        // this particular fact stumped me for a good two hours
-        public string id { get; set; }
-        public string link { get; set; }
-        public string deletehash { get; set; }
-        public string title;
-        public string description;
-        public System.Drawing.Image thumbnail { get; set; }
-        public bool anonymous;
-        public bool album { get; set; }
-        public DateTime timestamp { get; set; }
+        // Databound control: textBoxID
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-        // used for data binding
+        // Databound control: textBoxLink
+        [JsonProperty("link")]
+        public string Link { get; set; }
+
+        // Databound control: textBoxDeleteHash
+        [JsonProperty("deletehash")]
+        public string Deletehash { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        // Databound control: pictureBoxHistoryThumb
+        [JsonProperty("thumbnail")]
+        public Image Thumbnail { get; set; }
+
+        [JsonProperty("anonymous")]
+        public bool Anonymous { get; set; }
+
+        // Databound control: checkBoxAlbum
+        [JsonProperty("album")]
+        public bool Album { get; set; }
+
+        // Databound control: textBoxTimestamp
+        [JsonProperty("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+        // Databound control: checkBoxTiedToAccount
         [JsonIgnore]
-        public bool tiedToAccount { get { return !anonymous; } set { anonymous = !value; } }
+        public bool TiedToAccount
+        {
+            get { return !Anonymous; }
+        }
 
         [JsonIgnore]
-        public string listName
+        public string ListName
         {
             get
             {
-                return title + "//" + id;
+                return Title + "//" + Id;
             }
         }
     }

--- a/EasyImgur/ImgurAPI.cs
+++ b/EasyImgur/ImgurAPI.cs
@@ -195,19 +195,19 @@ namespace EasyImgur
                     // generally indicates a server failure; on problems such as 502 Proxy Error and 504 Gateway Timeout HTML is returned
                     // which can't be parsed by the JSON converter.
                     resp = new APIResponses.ImageResponse();
-                    resp.success = false;
-                    resp.status = status;
-                    resp.data = new APIResponses.ImageResponse.Data() { error = error };
+                    resp.Success = false;
+                    resp.Status = status;
+                    resp.ResponseData = new APIResponses.ImageResponse.Data() { Error = error };
                 }
 
-                if (resp.success)
+                if (resp.Success)
                 {
-                    Log.Info("Successfully uploaded image! (" + resp.status.ToString() + ")[\n\rid: " + resp.data.id + "\n\rlink: " + resp.data.link + "\n\rdeletehash: " + resp.data.deletehash + "\n\r]");
+                    Log.Info("Successfully uploaded image! (" + resp.Status.ToString() + ")[\n\rid: " + resp.ResponseData.Id + "\n\rlink: " + resp.ResponseData.Link + "\n\rdeletehash: " + resp.ResponseData.DeleteHash + "\n\r]");
                     ++m_NumUploads;
                 }
                 else
                 {
-                    Log.Error("Failed to upload image (" + resp.status.ToString() + ")");
+                    Log.Error("Failed to upload image (" + resp.Status.ToString() + ")");
                 }
             }
 
@@ -282,22 +282,22 @@ namespace EasyImgur
             }
 
             if(resp == null || responseString == "" || responseString == null)
-                resp = new APIResponses.AlbumResponse() { success = false };
+                resp = new APIResponses.AlbumResponse() { Success = false };
 
-            if(resp.success)
-                Log.Info("Successfully created album! (" + resp.status.ToString() + ")");
+            if(resp.Success)
+                Log.Info("Successfully created album! (" + resp.Status.ToString() + ")");
             else
             {
-                Log.Error("Failed to create album! (" + resp.status.ToString() + ")");
+                Log.Error("Failed to create album! (" + resp.Status.ToString() + ")");
                 return resp;
             }
 
             // sometimes this happens! it's weird.
-            if(_Anonymous && resp.data.deletehash == null)
+            if(_Anonymous && resp.ResponseData.DeleteHash == null)
             {
                 Log.Error("Anonymous album creation didn't return deletehash. Can't add to album.");
-                resp.success = false;
-                resp.data.error = "Imgur API error. Try again in a minute.";
+                resp.Success = false;
+                resp.ResponseData.Error = "Imgur API error. Try again in a minute.";
                 // can't even be responsible and delete our orphaned album
                 return resp;
             }
@@ -315,19 +315,19 @@ namespace EasyImgur
                 if (i < _Descriptions.Count())
                     description = _Descriptions[i];
 
-                responses.Add(InternalUploadImage(image, false, title, description, _Anonymous, _Anonymous ? resp.data.deletehash : resp.data.id));
+                responses.Add(InternalUploadImage(image, false, title, description, _Anonymous, _Anonymous ? resp.ResponseData.DeleteHash : resp.ResponseData.Id));
             }
 
             // since an album creation doesn't return very much in the manner of information, make a request to 
             // get the fully populated album
-            string deletehash = resp.data.deletehash; // save deletehash
+            string deletehash = resp.ResponseData.DeleteHash; // save deletehash
             responseString = "";
             using(WebClient t = new WebClient())
             {
                 t.Headers[HttpRequestHeader.Authorization] = GetAuthorizationHeader(_Anonymous);
                 try
                 {
-                    responseString = t.DownloadString(url + "/" + resp.data.id);
+                    responseString = t.DownloadString(url + "/" + resp.ResponseData.Id);
                 }
                 catch(System.Net.WebException ex)
                 {
@@ -364,15 +364,15 @@ namespace EasyImgur
             }
 
             if(resp == null || responseString == "" || responseString == null)
-                resp = new APIResponses.AlbumResponse() { success = false };
+                resp = new APIResponses.AlbumResponse() { Success = false };
 
-            resp.data.deletehash = deletehash;
+            resp.ResponseData.DeleteHash = deletehash;
 
-            if(resp.success)
+            if(resp.Success)
             {
                 int i = 0;
-                foreach(var response in resp.data.images)
-                    if(response.id == resp.data.cover)
+                foreach(var response in resp.ResponseData.Images)
+                    if(response.Id == resp.ResponseData.Cover)
                         break;
                     else
                         i++;
@@ -382,11 +382,11 @@ namespace EasyImgur
                     resp.CoverImage = null;
             }
 
-            if(resp.success)
-                Log.Info("Successfully created album! (" + resp.status.ToString() + ")");
+            if(resp.Success)
+                Log.Info("Successfully created album! (" + resp.Status.ToString() + ")");
             else
             {
-                Log.Error("Created album, but failed to get album information! (" + resp.status.ToString() + ")");
+                Log.Error("Created album, but failed to get album information! (" + resp.Status.ToString() + ")");
                 return oldResp;
             }
 
@@ -439,16 +439,16 @@ namespace EasyImgur
             if(resp == null || responseString == null || responseString == string.Empty)
             {
                 resp = new APIResponses.ImageResponse();
-                resp.success = false;
+                resp.Success = false;
             }
 
-            if(resp.success)
+            if(resp.Success)
             {
-                Log.Info("Successfully deleted album! (" + resp.status.ToString() + ")");
+                Log.Info("Successfully deleted album! (" + resp.Status.ToString() + ")");
                 return true;
             }
 
-            Log.Error("Failed to delete album! (" + resp.status.ToString() + ") [\n\rdeletehash: " + _DeleteHash + "\n\r]");
+            Log.Error("Failed to delete album! (" + resp.Status.ToString() + ") [\n\rdeletehash: " + _DeleteHash + "\n\r]");
             return false;
         }
 
@@ -498,16 +498,16 @@ namespace EasyImgur
             if (resp == null || responseString == null || responseString == string.Empty)
             {
                 resp = new APIResponses.ImageResponse();
-                resp.success = false;
+                resp.Success = false;
             }
 
-            if (resp.success)
+            if (resp.Success)
             {
-                Log.Info("Successfully deleted image! (" + resp.status.ToString() + ")");
+                Log.Info("Successfully deleted image! (" + resp.Status.ToString() + ")");
                 return true;
             }
 
-            Log.Error("Failed to delete image! (" + resp.status.ToString() + ") [\n\rdeletehash: " + _DeleteHash + "\n\r]");
+            Log.Error("Failed to delete image! (" + resp.Status.ToString() + ") [\n\rdeletehash: " + _DeleteHash + "\n\r]");
             return false;
         }
 
@@ -576,9 +576,9 @@ namespace EasyImgur
             }
 
             APIResponses.TokenResponse resp = Newtonsoft.Json.JsonConvert.DeserializeObject<APIResponses.TokenResponse>(responseString, new Newtonsoft.Json.JsonSerializerSettings { PreserveReferencesHandling = Newtonsoft.Json.PreserveReferencesHandling.Objects });
-            if (resp != null && resp.access_token != null && resp.refresh_token != null)
+            if (resp != null && resp.AccessToken != null && resp.RefreshToken!= null)
             {
-                StoreNewTokens(resp.expires_in, resp.access_token, resp.refresh_token);
+                StoreNewTokens(resp.ExpiresIn, resp.AccessToken, resp.RefreshToken);
 
                 Log.Info("Received tokens from PIN");
 
@@ -682,9 +682,9 @@ namespace EasyImgur
             {
                 Log.Error("Unexpected Exception: " + ex.ToString());
             }
-            if (resp != null && resp.access_token != null && resp.refresh_token != null)
+            if (resp != null && resp.AccessToken != null && resp.RefreshToken!= null)
             {
-                StoreNewTokens(resp.expires_in, resp.access_token, resp.refresh_token);
+                StoreNewTokens(resp.ExpiresIn, resp.AccessToken, resp.RefreshToken);
 
                 Log.Info("Refreshed tokens");
 

--- a/EasyImgur/StatisticsMetrics/Metrics.cs
+++ b/EasyImgur/StatisticsMetrics/Metrics.cs
@@ -13,7 +13,7 @@ namespace EasyImgur.StatisticsMetrics
     {
         protected override Object Gather()
         {
-            return History.count;
+            return History.Count;
         }
     }
 
@@ -21,7 +21,7 @@ namespace EasyImgur.StatisticsMetrics
     {
         protected override Object Gather()
         {
-            return History.anonymousCount;
+            return History.AnonymousCount;
         }
     }
 


### PR DESCRIPTION
* Refactored the `HistoryItem` and `History` classes and all classes in the `EasyImgur.APIResponses` namespace
 * All aforementioned classes now adhere to the [Microsoft Naming Guidelines](https://msdn.microsoft.com/en-us/library/ms229002(v=vs.110).aspx)
 * Added `JsonProperty` attributes to maintain compatibility with the API
 * Public properties instead of fields <sup>1</sup>

Are you cool with this kind of refactoring or do you wish that contributors comply with your own naming conventions? (e.g. C++-ish method definitions like `void DoStuff( String _Param1 )` instead of `void DoStuff(string param1)`)

Clearly consistency is key so I'll gladly refactor the whole project.

___
<sup>1</sup>: https://msdn.microsoft.com/en-us/library/ms229057(v=vs.110).aspx